### PR TITLE
Initial CP932 Implementation with Python Codecs Compatibility

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+linters:
+  default: standard
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+  settings:
+    golines:
+      max-len: 120
+
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: test test-coverage clean lint fmt
+
+# テストを実行
+test:
+	go test -v ./...
+
+# テストカバレッジを表示
+test-coverage:
+	go test -v -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
+
+# リンティングを実行
+lint:
+	golangci-lint run
+
+# フォーマットを実行
+fmt:
+	golangci-lint fmt
+
+# クリーンアップ
+clean:
+	go clean
+	rm -f coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 .PHONY: test test-coverage clean lint fmt
 
-# テストを実行
+# Run tests
 test:
 	go test -v ./...
 
-# テストカバレッジを表示
+# Show test coverage
 test-coverage:
 	go test -v -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
 
-# リンティングを実行
+# Run linting
 lint:
 	golangci-lint run
 
-# フォーマットを実行
+# Run formatting
 fmt:
 	golangci-lint fmt
 
-# クリーンアップ
+# Clean up
 clean:
 	go clean
 	rm -f coverage.out

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
 # pytextcodec
+
 Go package for text encoding/decoding compatible with Python's codecs
+
+## Overview
+
+This package provides text encoding/decoding functionality compatible with Python's codecs. It can be used in the same way as `golang.org/x/text/transform`, allowing you to simply replace the Transformer.
+
+## Installation
+
+```bash
+go get github.com/akihiroy/pytextcodec
+```
+
+## Usage
+
+### CP932 Encoding
+
+```go
+import (
+    "github.com/akihiroy/pytextcodec/japanese"
+    "golang.org/x/text/transform"
+)
+
+// Using encoder
+encoder := japanese.CP932.NewEncoder()
+encoded, _, err := transform.Bytes(encoder, []byte("こんにちは"))
+
+// Using decoder
+decoder := japanese.CP932.NewDecoder()
+decoded, _, err := transform.Bytes(decoder, encoded)
+
+// Combining with transform.NewReader
+reader := transform.NewReader(sjisFile, japanese.CP932.NewDecoder())
+```
+
+## Development
+
+### Running Tests
+
+First, generate test data:
+
+```bash
+uv run japanese/testdata/generate_testdata.py
+```
+
+Then run the tests:
+
+```bash
+make test
+```
+
+### Linting
+
+```bash
+make lint
+```
+
+### Viewing Test Coverage
+
+```bash
+make test-coverage
+```
+
+## Supported Encodings
+
+- CP932 (Shift_JIS)
+
+## License
+
+MIT License

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,16 @@
+module github.com/akihiroy/pytextcodec
+
+go 1.23.3
+
+require (
+	github.com/stretchr/testify v1.10.0
+	github.com/vmihailenco/msgpack/v5 v5.4.1
+	golang.org/x/text v0.28.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
+golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/japanese/cp932.go
+++ b/japanese/cp932.go
@@ -1,0 +1,172 @@
+package japanese
+
+import (
+	"errors"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/transform"
+)
+
+var (
+	errInvalidRune           = errors.New("Transform: invalid rune")
+	errInconsistentByteCount = errors.New("Transform: inconsistent byte count returned")
+)
+
+// CP932 is the CP932 encoding, compatible with CPython's implementation.
+var CP932 encoding.Encoding = &cp932{}
+
+type cp932 struct{}
+
+func (c *cp932) NewDecoder() *encoding.Decoder {
+	return &encoding.Decoder{Transformer: &cp932Decoder{decoder: japanese.ShiftJIS.NewDecoder()}}
+}
+
+func (c *cp932) NewEncoder() *encoding.Encoder {
+	return &encoding.Encoder{Transformer: &cp932Encoder{encoder: japanese.ShiftJIS.NewEncoder()}}
+}
+
+type cp932Decoder struct {
+	transform.NopResetter
+
+	decoder *encoding.Decoder
+}
+
+var _ transform.Transformer = (*cp932Decoder)(nil)
+
+// Uses japanese.ShiftJIS decoder as base, with CPython code as reference for parts with different specifications
+// https://github.com/python/cpython/blob/8a0c7f1e402768c7e806e2472e0a493c1800851f/Modules/cjkcodecs/_codecs_jp.c#L84
+func (c *cp932Decoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	for nSrc < len(src) {
+		var r rune
+		size := 0
+		switch c0 := src[nSrc]; {
+		case c0 == 0xA0:
+			r, size = 0xF8F0, 1
+		case c0 >= 0xF0 && c0 <= 0xF9:
+			if nSrc+1 >= len(src) {
+				return nDst, nSrc, transform.ErrShortSrc
+			}
+
+			switch c1 := src[nSrc+1]; {
+			case c1 >= 0x40 && c1 <= 0x7E:
+				r, size = rune(0xE000+188*(int(c0)-0xF0)+(int(c1)-0x40)), 2
+			case c1 >= 0x80 && c1 <= 0xFC:
+				r, size = rune(0xE000+188*(int(c0)-0xF0)+(int(c1)-0x41)), 2
+			default:
+				r, size = '\ufffd', 1
+			}
+		case c0 >= 0xFD:
+			r, size = rune(0xF8F1-0xFD+int(c0)), 1
+		default:
+			size = min(len(src)-nSrc, 2)
+			eof := atEOF && nSrc+size == len(src)
+			d, s, err := c.decoder.Transform(dst[nDst:], src[nSrc:nSrc+size], eof)
+			nDst += d
+			nSrc += s
+			// Continue if ErrShortSrc occurs but there's more data to process
+			if err != nil && (err != transform.ErrShortSrc || eof) {
+				return nDst, nSrc, err
+			}
+			if s == 0 {
+				return nDst, nSrc, errInconsistentByteCount
+			}
+			continue
+		}
+		if size > 0 {
+			runeLen := utf8.RuneLen(r)
+			if runeLen == -1 {
+				return nDst, nSrc, errInvalidRune
+			}
+			if nDst+runeLen > len(dst) {
+				return nDst, nSrc, transform.ErrShortDst
+			}
+			nDst += utf8.EncodeRune(dst[nDst:], r)
+			nSrc += size
+		}
+	}
+	return nDst, nSrc, nil
+}
+
+type cp932Encoder struct {
+	transform.NopResetter
+
+	encoder *encoding.Encoder
+}
+
+var _ transform.Transformer = (*cp932Encoder)(nil)
+
+// Uses japanese.ShiftJIS encoder as base, with CPython code as reference for parts with different specifications
+// https://github.com/python/cpython/blob/8a0c7f1e402768c7e806e2472e0a493c1800851f/Modules/cjkcodecs/_codecs_jp.c#L20
+func (c *cp932Encoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	for nSrc < len(src) {
+		r, size := rune(src[nSrc]), 1
+		if r >= utf8.RuneSelf {
+			r, size = utf8.DecodeRune(src[nSrc:])
+			if size == 1 {
+				if !atEOF && !utf8.FullRune(src[nSrc:]) {
+					return nDst, nSrc, transform.ErrShortSrc
+				}
+			}
+		}
+
+		var d0, d1 byte
+		switch {
+		case r == 0x80:
+			dst[nDst] = 0x80
+			nDst++
+			nSrc += size
+			continue
+		case r == 0xA2: // cent sign
+			d0, d1 = 0x81, 0x91
+		case r == 0xA3: // pound sign
+			d0, d1 = 0x81, 0x92
+		case r == 0xAC: // not sign
+			d0, d1 = 0x81, 0xCA
+		case r == 0x2016: // double vertical line
+			d0, d1 = 0x81, 0x61
+		case r == 0x2212: // minus sign
+			d0, d1 = 0x81, 0x7c
+		case r == 0x301C: // wave dash
+			d0, d1 = 0x81, 0x60
+		case r >= 0xE000 && r < 0xE758:
+			d0 = 0xF0 + byte((r-0xE000)/188)
+			d1 = byte((r - 0xE000) % 188)
+			if d1 < 0x3F {
+				d1 += 0x40
+			} else {
+				d1 += 0x41
+			}
+		case r == 0xF8F0:
+			dst[nDst] = 0xA0
+			nDst++
+			nSrc += size
+			continue
+		case r >= 0xF8F1 && r <= 0xF8F3:
+			dst[nDst] = 0xFD + byte(r-0xF8F1)
+			nDst++
+			nSrc += size
+			continue
+		default:
+			eof := atEOF && nSrc+size == len(src)
+			d, s, err := c.encoder.Transform(dst[nDst:], src[nSrc:nSrc+size], eof)
+			nDst += d
+			nSrc += s
+			if err != nil {
+				return nDst, nSrc, err
+			}
+			continue
+		}
+
+		// Write 2 bytes
+		if nDst+2 > len(dst) {
+			return nDst, nSrc, transform.ErrShortDst
+		}
+		dst[nDst] = d0
+		dst[nDst+1] = d1
+		nDst += 2
+		nSrc += size
+	}
+	return nDst, nSrc, nil
+}

--- a/japanese/cp932_test.go
+++ b/japanese/cp932_test.go
@@ -1,0 +1,318 @@
+package japanese_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/akihiroy/pytextcodec/japanese"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+	"golang.org/x/text/transform"
+)
+
+// TestData structures for MessagePack files
+type (
+	EncoderTestData map[string][]byte
+	DecoderTestData map[string]string
+)
+
+// loadEncoderTestData loads encoder test data from MessagePack file
+func loadEncoderTestData(t *testing.T) EncoderTestData {
+	// Get the directory where this test file is located
+	testDir := filepath.Dir(".")
+	testDataDir := filepath.Join(testDir, "testdata")
+
+	// Load encoder test data
+	encoderFile := filepath.Join(testDataDir, "cp932_encoder.msgpack")
+	encoderData, err := os.ReadFile(encoderFile)
+	if err != nil {
+		t.Fatalf("Failed to read encoder test data: %v", err)
+	}
+
+	var encoderTestData EncoderTestData
+	if err := msgpack.Unmarshal(encoderData, &encoderTestData); err != nil {
+		t.Fatalf("Failed to unmarshal encoder test data: %v", err)
+	}
+
+	return encoderTestData
+}
+
+// loadDecoderTestData loads decoder test data from MessagePack file
+func loadDecoderTestData(t *testing.T) DecoderTestData {
+	// Get the directory where this test file is located
+	testDir := filepath.Dir(".")
+	testDataDir := filepath.Join(testDir, "testdata")
+
+	// Load decoder test data
+	decoderFile := filepath.Join(testDataDir, "cp932_decoder.msgpack")
+	decoderData, err := os.ReadFile(decoderFile)
+	if err != nil {
+		t.Fatalf("Failed to read decoder test data: %v", err)
+	}
+
+	var decoderTestData DecoderTestData
+	if err := msgpack.Unmarshal(decoderData, &decoderTestData); err != nil {
+		t.Fatalf("Failed to unmarshal decoder test data: %v", err)
+	}
+
+	return decoderTestData
+}
+
+// TestCP932EncoderWithTestData tests encoder using comprehensive Unicode ranges
+func TestCP932EncoderWithTestData(t *testing.T) {
+	t.Parallel()
+	encoderTestData := loadEncoderTestData(t)
+
+	// Prepare test cases for Unicode ranges
+	var testCases []struct {
+		name       string
+		startRange uint32
+		endRange   uint32
+	}
+
+	// Create test cases for each upper word (0x000000-0x10FFFF)
+	for upperWord := uint32(0); upperWord <= 0x10; upperWord++ {
+		startRange := upperWord << 16
+		endRange := startRange + 0xFFFF
+		if upperWord == 0x10 {
+			endRange = 0x10FFFF // Last range ends at 0x10FFFF
+		}
+
+		testCases = append(testCases, struct {
+			name       string
+			startRange uint32
+			endRange   uint32
+		}{
+			name:       fmt.Sprintf("range_0x%05X_0x%05X", startRange, endRange),
+			startRange: startRange,
+			endRange:   endRange,
+		})
+	}
+
+	// Execute all test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoder := japanese.CP932.NewEncoder()
+
+			// Test each code point in the range
+			for code := tc.startRange; code <= tc.endRange; code++ {
+				codeStr := fmt.Sprintf("U+%06X", code)
+				expectedBytes, exists := encoderTestData[codeStr]
+
+				// Convert code point to character
+				char := rune(code)
+				runeLen := utf8.RuneLen(char)
+				if runeLen == -1 {
+					require.False(t, exists, "Invalid code point %s should not exist in test data", codeStr)
+					continue
+				}
+				input := make([]byte, runeLen)
+				utf8.EncodeRune(input, char)
+
+				// Encode using our CP932 implementation
+				result, _, err := transform.Bytes(encoder, input)
+				if exists {
+					require.NoError(t, err, "Encoding failed for %s. Expected: 0x%x", codeStr, expectedBytes)
+					// Compare with expected result
+					require.Equal(t, expectedBytes, result, "Encoding mismatch for %s", codeStr)
+				} else {
+					require.Error(t, err, "Encoding should fail for %s", codeStr)
+				}
+
+			}
+		})
+	}
+}
+
+// TestCP932DecoderWithTestData tests decoder using comprehensive byte combinations
+func TestCP932DecoderWithTestData(t *testing.T) {
+	t.Parallel()
+	decoderTestData := loadDecoderTestData(t)
+
+	// Prepare test cases for each c0 value (0x00-0xFF)
+	var testCases []struct {
+		name       string
+		c0         int
+		singleByte bool
+	}
+
+	for c0 := 0x00; c0 <= 0xFF; c0++ {
+		if isSingleByteRange(c0) {
+			// Single-byte character
+			testCases = append(testCases, struct {
+				name       string
+				c0         int
+				singleByte bool
+			}{
+				name:       fmt.Sprintf("0x%02X", c0),
+				c0:         c0,
+				singleByte: true, // single-byte
+			})
+		} else {
+			// 2-byte character
+			testCases = append(testCases, struct {
+				name       string
+				c0         int
+				singleByte bool
+			}{
+				name:       fmt.Sprintf("0x%02X", c0),
+				c0:         c0,
+				singleByte: false, // double-byte
+			})
+		}
+	}
+
+	// Execute all test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			decoder := japanese.CP932.NewDecoder()
+
+			if tc.singleByte {
+				// Test single-byte decoding
+				inputBytes := []byte{byte(tc.c0)}
+				expectedCodeStr, exists := decoderTestData[fmt.Sprintf("%02X", tc.c0)]
+
+				if !exists {
+					// This byte is not valid as single-byte in CP932
+					// Expected to return 0xFFFD (REPLACEMENT CHARACTER)
+					expectedCodeStr = "U+00FFFD"
+				}
+
+				// Test decoding result
+				testDecodingResult(t, decoder, inputBytes, expectedCodeStr, fmt.Sprintf("single-byte 0x%02X", tc.c0))
+			} else {
+				// Test all 2-byte combinations for this c0 value
+				for c1 := 0x00; c1 <= 0xFF; c1++ {
+					inputBytes := []byte{byte(tc.c0), byte(c1)}
+					expectedCodeStr, exists := decoderTestData[fmt.Sprintf("%02X%02X", tc.c0, c1)]
+
+					if !exists {
+						// This byte combination is not valid in CP932
+						// Expected to return 0xFFFD (REPLACEMENT CHARACTER)
+						expectedCodeStr = "U+00FFFD"
+					}
+
+					// Test decoding result
+					testDecodingResult(t, decoder, inputBytes, expectedCodeStr, fmt.Sprintf("0x%02X%02X", tc.c0, c1))
+				}
+			}
+		})
+	}
+}
+
+// testDecodingResult is a helper function to test decoding results
+func testDecodingResult(
+	t *testing.T,
+	decoder transform.Transformer,
+	inputBytes []byte,
+	expectedCodeStr, testName string,
+) {
+	result, _, err := transform.Bytes(decoder, inputBytes)
+	assert.NoError(t, err, "Decoding failed for valid %s", testName)
+	assert.NotEmpty(t, result, "Decoding result is empty for valid %s", testName)
+
+	runes := []rune(string(result))
+	assert.NotEmpty(t, runes, "No runes in decoding result for %s", testName)
+
+	actualCodeStr := fmt.Sprintf("U+%06X", runes[0])
+	assert.Equal(t, expectedCodeStr, actualCodeStr, "Decoding mismatch for %s", testName)
+}
+
+// isSingleByteRange checks if the byte value corresponds to single-byte character range
+func isSingleByteRange(c0 int) bool {
+	return c0 <= 0x80 || (0xA0 <= c0 && c0 <= 0xDF) || (0xFD <= c0 && c0 <= 0xFF)
+}
+
+// Legacy tests (keeping for backward compatibility)
+func TestCP932Encoding(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected []byte
+	}{
+		{
+			name:     "ASCII characters",
+			input:    "Hello, World!",
+			expected: []byte("Hello, World!"),
+		},
+		{
+			name:     "Japanese characters",
+			input:    "こんにちは〜", // includes wave dash (U+301C)
+			expected: []byte{0x82, 0xB1, 0x82, 0xF1, 0x82, 0xC9, 0x82, 0xBF, 0x82, 0xCD, 0x81, 0x60},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoder := japanese.CP932.NewEncoder()
+			result, _, err := transform.Bytes(encoder, []byte(tt.input))
+			assert.NoError(t, err, "Encoding error")
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCP932Decoding(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "ASCII characters",
+			input:    []byte("Hello, World!"),
+			expected: "Hello, World!",
+		},
+		{
+			name:     "Japanese characters",
+			input:    []byte{0x82, 0xB1, 0x82, 0xF1, 0x82, 0xC9, 0x82, 0xBF, 0x82, 0xCD},
+			expected: "こんにちは",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoder := japanese.CP932.NewDecoder()
+			result, _, err := transform.Bytes(decoder, tt.input)
+			assert.NoError(t, err, "Decoding error")
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestCP932RoundTrip(t *testing.T) {
+	testStrings := []string{
+		"Hello, World!",
+		"こんにちは～", // includes full-width tilde (U+FF5E)
+		"Hello, 世界!",
+		"プログラミング",
+	}
+
+	for _, input := range testStrings {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			// Encode
+			encoder := japanese.CP932.NewEncoder()
+			encoded, _, err := transform.Bytes(encoder, []byte(input))
+			assert.NoError(t, err, "Encoding error")
+
+			// Decode
+			decoder := japanese.CP932.NewDecoder()
+			decoded, _, err := transform.Bytes(decoder, encoded)
+			assert.NoError(t, err, "Decoding error")
+
+			assert.Equal(t, input, string(decoded), "Round trip failed")
+		})
+	}
+}

--- a/japanese/testdata/generate_testdata.py
+++ b/japanese/testdata/generate_testdata.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Script to generate CP932 encoder and decoder test data
+
+- Encoder data: key is unicode codepoint, value is cp932 byte sequence
+- Decoder data: key is cp932 byte sequence, value is unicode codepoint
+"""
+
+import os
+from typing import Dict
+
+import msgpack
+
+
+def generate_cp932_encoder_data() -> Dict[str, bytes]:
+    """
+    Generate test data for CP932 encoder
+    key: unicode codepoint (0~0x10FFFF) as string
+    value: cp932 byte sequence
+    """
+    encoder_data = {}
+
+    # Process entire Unicode range (0x000000 - 0x10FFFF)
+    for i in range(0x110000):
+        try:
+            char = chr(i)
+            encoded = char.encode("cp932")
+            if encoded:
+                encoder_data[f"U+{i:06X}"] = encoded
+        except (UnicodeEncodeError, LookupError):
+            pass
+
+    return encoder_data
+
+
+def generate_cp932_decoder_data() -> Dict[str, str]:
+    """
+    Generate test data for CP932 decoder
+    key: cp932 byte sequence as hex string
+    value: unicode codepoint as string
+    """
+    decoder_data = {}
+
+    for c0 in range(0x100):  # 0x00-0xFF
+        for c1 in range(0x100):  # 0x00-0xFF
+            # If c0 corresponds to single-byte character range, perform single-byte decoding
+            if c0 <= 0x80 or (0xA0 <= c0 <= 0xDF) or (0xFD <= c0 <= 0xFF):
+                try:
+                    byte_seq = bytes([c0])
+                    decoded = byte_seq.decode("cp932")
+                    if decoded:
+                        decoder_data[f"{c0:02X}"] = f"U+{ord(decoded):06X}"
+                except (UnicodeDecodeError, LookupError):
+                    pass
+                break  # Skip 2-byte processing for single-byte characters
+
+            # 2-byte character processing
+            try:
+                byte_seq = bytes([c0, c1])
+                decoded = byte_seq.decode("cp932")
+                if decoded:
+                    decoder_data[f"{c0:02X}{c1:02X}"] = f"U+{ord(decoded):06X}"
+            except (UnicodeDecodeError, LookupError):
+                pass
+
+    return decoder_data
+
+
+def save_testdata(encoder_data: Dict[str, bytes], decoder_data: Dict[str, str]):
+    """Save test data to MessagePack files"""
+    output_dir = os.path.dirname(__file__)
+
+    # Save encoder data
+    encoder_file = os.path.join(output_dir, "cp932_encoder.msgpack")
+    with open(encoder_file, "wb") as f:
+        msgpack.pack(encoder_data, f)
+    print(f"Encoder test data saved: {encoder_file}")
+    print(f"  Data count: {len(encoder_data)}")
+
+    # Save decoder data
+    decoder_file = os.path.join(output_dir, "cp932_decoder.msgpack")
+    with open(decoder_file, "wb") as f:
+        msgpack.pack(decoder_data, f)
+    print(f"Decoder test data saved: {decoder_file}")
+    print(f"  Data count: {len(decoder_data)}")
+
+
+def main():
+    """Main processing"""
+    print("Starting japanese test data generation...")
+
+    print("Generating encoder data for CP932...")
+    encoder_data = generate_cp932_encoder_data()
+
+    print("Generating decoder data for CP932...")
+    decoder_data = generate_cp932_decoder_data()
+
+    save_testdata(encoder_data, decoder_data)
+
+    print("Test data generation completed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "pytextcodec"
+version = "0.1.0"
+description = "Go package for text encoding/decoding compatible with Python's codecs"
+
+[tool.uv]
+dev-dependencies = [
+    "msgpack>=1.0.0",
+    "ruff>=0.12.8",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,85 @@
+version = 1
+revision = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "msgpack"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/b1/ea4f68038a18c77c9467400d166d74c4ffa536f34761f7983a104357e614/msgpack-1.1.1.tar.gz", hash = "sha256:77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd", size = 173555 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/83/97f24bf9848af23fe2ba04380388216defc49a8af6da0c28cc636d722502/msgpack-1.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:71ef05c1726884e44f8b1d1773604ab5d4d17729d8491403a705e649116c9558", size = 82728 },
+    { url = "https://files.pythonhosted.org/packages/aa/7f/2eaa388267a78401f6e182662b08a588ef4f3de6f0eab1ec09736a7aaa2b/msgpack-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:36043272c6aede309d29d56851f8841ba907a1a3d04435e43e8a19928e243c1d", size = 79279 },
+    { url = "https://files.pythonhosted.org/packages/f8/46/31eb60f4452c96161e4dfd26dbca562b4ec68c72e4ad07d9566d7ea35e8a/msgpack-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a32747b1b39c3ac27d0670122b57e6e57f28eefb725e0b625618d1b59bf9d1e0", size = 423859 },
+    { url = "https://files.pythonhosted.org/packages/45/16/a20fa8c32825cc7ae8457fab45670c7a8996d7746ce80ce41cc51e3b2bd7/msgpack-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a8b10fdb84a43e50d38057b06901ec9da52baac6983d3f709d8507f3889d43f", size = 429975 },
+    { url = "https://files.pythonhosted.org/packages/86/ea/6c958e07692367feeb1a1594d35e22b62f7f476f3c568b002a5ea09d443d/msgpack-1.1.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ba0c325c3f485dc54ec298d8b024e134acf07c10d494ffa24373bea729acf704", size = 413528 },
+    { url = "https://files.pythonhosted.org/packages/75/05/ac84063c5dae79722bda9f68b878dc31fc3059adb8633c79f1e82c2cd946/msgpack-1.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:88daaf7d146e48ec71212ce21109b66e06a98e5e44dca47d853cbfe171d6c8d2", size = 413338 },
+    { url = "https://files.pythonhosted.org/packages/69/e8/fe86b082c781d3e1c09ca0f4dacd457ede60a13119b6ce939efe2ea77b76/msgpack-1.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d8b55ea20dc59b181d3f47103f113e6f28a5e1c89fd5b67b9140edb442ab67f2", size = 422658 },
+    { url = "https://files.pythonhosted.org/packages/3b/2b/bafc9924df52d8f3bb7c00d24e57be477f4d0f967c0a31ef5e2225e035c7/msgpack-1.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4a28e8072ae9779f20427af07f53bbb8b4aa81151054e882aee333b158da8752", size = 427124 },
+    { url = "https://files.pythonhosted.org/packages/a2/3b/1f717e17e53e0ed0b68fa59e9188f3f610c79d7151f0e52ff3cd8eb6b2dc/msgpack-1.1.1-cp311-cp311-win32.whl", hash = "sha256:7da8831f9a0fdb526621ba09a281fadc58ea12701bc709e7b8cbc362feabc295", size = 65016 },
+    { url = "https://files.pythonhosted.org/packages/48/45/9d1780768d3b249accecc5a38c725eb1e203d44a191f7b7ff1941f7df60c/msgpack-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:5fd1b58e1431008a57247d6e7cc4faa41c3607e8e7d4aaf81f7c29ea013cb458", size = 72267 },
+    { url = "https://files.pythonhosted.org/packages/e3/26/389b9c593eda2b8551b2e7126ad3a06af6f9b44274eb3a4f054d48ff7e47/msgpack-1.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ae497b11f4c21558d95de9f64fff7053544f4d1a17731c866143ed6bb4591238", size = 82359 },
+    { url = "https://files.pythonhosted.org/packages/ab/65/7d1de38c8a22cf8b1551469159d4b6cf49be2126adc2482de50976084d78/msgpack-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33be9ab121df9b6b461ff91baac6f2731f83d9b27ed948c5b9d1978ae28bf157", size = 79172 },
+    { url = "https://files.pythonhosted.org/packages/0f/bd/cacf208b64d9577a62c74b677e1ada005caa9b69a05a599889d6fc2ab20a/msgpack-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f64ae8fe7ffba251fecb8408540c34ee9df1c26674c50c4544d72dbf792e5ce", size = 425013 },
+    { url = "https://files.pythonhosted.org/packages/4d/ec/fd869e2567cc9c01278a736cfd1697941ba0d4b81a43e0aa2e8d71dab208/msgpack-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a494554874691720ba5891c9b0b39474ba43ffb1aaf32a5dac874effb1619e1a", size = 426905 },
+    { url = "https://files.pythonhosted.org/packages/55/2a/35860f33229075bce803a5593d046d8b489d7ba2fc85701e714fc1aaf898/msgpack-1.1.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb643284ab0ed26f6957d969fe0dd8bb17beb567beb8998140b5e38a90974f6c", size = 407336 },
+    { url = "https://files.pythonhosted.org/packages/8c/16/69ed8f3ada150bf92745fb4921bd621fd2cdf5a42e25eb50bcc57a5328f0/msgpack-1.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d275a9e3c81b1093c060c3837e580c37f47c51eca031f7b5fb76f7b8470f5f9b", size = 409485 },
+    { url = "https://files.pythonhosted.org/packages/c6/b6/0c398039e4c6d0b2e37c61d7e0e9d13439f91f780686deb8ee64ecf1ae71/msgpack-1.1.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4fd6b577e4541676e0cc9ddc1709d25014d3ad9a66caa19962c4f5de30fc09ef", size = 412182 },
+    { url = "https://files.pythonhosted.org/packages/b8/d0/0cf4a6ecb9bc960d624c93effaeaae75cbf00b3bc4a54f35c8507273cda1/msgpack-1.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb29aaa613c0a1c40d1af111abf025f1732cab333f96f285d6a93b934738a68a", size = 419883 },
+    { url = "https://files.pythonhosted.org/packages/62/83/9697c211720fa71a2dfb632cad6196a8af3abea56eece220fde4674dc44b/msgpack-1.1.1-cp312-cp312-win32.whl", hash = "sha256:870b9a626280c86cff9c576ec0d9cbcc54a1e5ebda9cd26dab12baf41fee218c", size = 65406 },
+    { url = "https://files.pythonhosted.org/packages/c0/23/0abb886e80eab08f5e8c485d6f13924028602829f63b8f5fa25a06636628/msgpack-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:5692095123007180dca3e788bb4c399cc26626da51629a31d40207cb262e67f4", size = 72558 },
+    { url = "https://files.pythonhosted.org/packages/a1/38/561f01cf3577430b59b340b51329803d3a5bf6a45864a55f4ef308ac11e3/msgpack-1.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3765afa6bd4832fc11c3749be4ba4b69a0e8d7b728f78e68120a157a4c5d41f0", size = 81677 },
+    { url = "https://files.pythonhosted.org/packages/09/48/54a89579ea36b6ae0ee001cba8c61f776451fad3c9306cd80f5b5c55be87/msgpack-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8ddb2bcfd1a8b9e431c8d6f4f7db0773084e107730ecf3472f1dfe9ad583f3d9", size = 78603 },
+    { url = "https://files.pythonhosted.org/packages/a0/60/daba2699b308e95ae792cdc2ef092a38eb5ee422f9d2fbd4101526d8a210/msgpack-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:196a736f0526a03653d829d7d4c5500a97eea3648aebfd4b6743875f28aa2af8", size = 420504 },
+    { url = "https://files.pythonhosted.org/packages/20/22/2ebae7ae43cd8f2debc35c631172ddf14e2a87ffcc04cf43ff9df9fff0d3/msgpack-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d592d06e3cc2f537ceeeb23d38799c6ad83255289bb84c2e5792e5a8dea268a", size = 423749 },
+    { url = "https://files.pythonhosted.org/packages/40/1b/54c08dd5452427e1179a40b4b607e37e2664bca1c790c60c442c8e972e47/msgpack-1.1.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4df2311b0ce24f06ba253fda361f938dfecd7b961576f9be3f3fbd60e87130ac", size = 404458 },
+    { url = "https://files.pythonhosted.org/packages/2e/60/6bb17e9ffb080616a51f09928fdd5cac1353c9becc6c4a8abd4e57269a16/msgpack-1.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e4141c5a32b5e37905b5940aacbc59739f036930367d7acce7a64e4dec1f5e0b", size = 405976 },
+    { url = "https://files.pythonhosted.org/packages/ee/97/88983e266572e8707c1f4b99c8fd04f9eb97b43f2db40e3172d87d8642db/msgpack-1.1.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b1ce7f41670c5a69e1389420436f41385b1aa2504c3b0c30620764b15dded2e7", size = 408607 },
+    { url = "https://files.pythonhosted.org/packages/bc/66/36c78af2efaffcc15a5a61ae0df53a1d025f2680122e2a9eb8442fed3ae4/msgpack-1.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4147151acabb9caed4e474c3344181e91ff7a388b888f1e19ea04f7e73dc7ad5", size = 424172 },
+    { url = "https://files.pythonhosted.org/packages/8c/87/a75eb622b555708fe0427fab96056d39d4c9892b0c784b3a721088c7ee37/msgpack-1.1.1-cp313-cp313-win32.whl", hash = "sha256:500e85823a27d6d9bba1d057c871b4210c1dd6fb01fbb764e37e4e8847376323", size = 65347 },
+    { url = "https://files.pythonhosted.org/packages/ca/91/7dc28d5e2a11a5ad804cf2b7f7a5fcb1eb5a4966d66a5d2b41aee6376543/msgpack-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:6d489fba546295983abd142812bda76b57e33d0b9f5d5b71c09a583285506f69", size = 72341 },
+]
+
+[[package]]
+name = "pytextcodec"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "msgpack" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "msgpack", specifier = ">=1.0.0" },
+    { name = "ruff", specifier = ">=0.12.8" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.12.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/da/5bd7565be729e86e1442dad2c9a364ceeff82227c2dece7c29697a9795eb/ruff-0.12.8.tar.gz", hash = "sha256:4cb3a45525176e1009b2b64126acf5f9444ea59066262791febf55e40493a033", size = 5242373 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/1e/c843bfa8ad1114fab3eb2b78235dda76acd66384c663a4e0415ecc13aa1e/ruff-0.12.8-py3-none-linux_armv6l.whl", hash = "sha256:63cb5a5e933fc913e5823a0dfdc3c99add73f52d139d6cd5cc8639d0e0465513", size = 11675315 },
+    { url = "https://files.pythonhosted.org/packages/24/ee/af6e5c2a8ca3a81676d5480a1025494fd104b8896266502bb4de2a0e8388/ruff-0.12.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a9bbe28f9f551accf84a24c366c1aa8774d6748438b47174f8e8565ab9dedbc", size = 12456653 },
+    { url = "https://files.pythonhosted.org/packages/99/9d/e91f84dfe3866fa648c10512904991ecc326fd0b66578b324ee6ecb8f725/ruff-0.12.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2fae54e752a3150f7ee0e09bce2e133caf10ce9d971510a9b925392dc98d2fec", size = 11659690 },
+    { url = "https://files.pythonhosted.org/packages/fe/ac/a363d25ec53040408ebdd4efcee929d48547665858ede0505d1d8041b2e5/ruff-0.12.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0acbcf01206df963d9331b5838fb31f3b44fa979ee7fa368b9b9057d89f4a53", size = 11896923 },
+    { url = "https://files.pythonhosted.org/packages/58/9f/ea356cd87c395f6ade9bb81365bd909ff60860975ca1bc39f0e59de3da37/ruff-0.12.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ae3e7504666ad4c62f9ac8eedb52a93f9ebdeb34742b8b71cd3cccd24912719f", size = 11477612 },
+    { url = "https://files.pythonhosted.org/packages/1a/46/92e8fa3c9dcfd49175225c09053916cb97bb7204f9f899c2f2baca69e450/ruff-0.12.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb82efb5d35d07497813a1c5647867390a7d83304562607f3579602fa3d7d46f", size = 13182745 },
+    { url = "https://files.pythonhosted.org/packages/5e/c4/f2176a310f26e6160deaf661ef60db6c3bb62b7a35e57ae28f27a09a7d63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dbea798fc0065ad0b84a2947b0aff4233f0cb30f226f00a2c5850ca4393de609", size = 14206885 },
+    { url = "https://files.pythonhosted.org/packages/87/9d/98e162f3eeeb6689acbedbae5050b4b3220754554526c50c292b611d3a63/ruff-0.12.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49ebcaccc2bdad86fd51b7864e3d808aad404aab8df33d469b6e65584656263a", size = 13639381 },
+    { url = "https://files.pythonhosted.org/packages/81/4e/1b7478b072fcde5161b48f64774d6edd59d6d198e4ba8918d9f4702b8043/ruff-0.12.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ac9c570634b98c71c88cb17badd90f13fc076a472ba6ef1d113d8ed3df109fb", size = 12613271 },
+    { url = "https://files.pythonhosted.org/packages/e8/67/0c3c9179a3ad19791ef1b8f7138aa27d4578c78700551c60d9260b2c660d/ruff-0.12.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:560e0cd641e45591a3e42cb50ef61ce07162b9c233786663fdce2d8557d99818", size = 12847783 },
+    { url = "https://files.pythonhosted.org/packages/4e/2a/0b6ac3dd045acf8aa229b12c9c17bb35508191b71a14904baf99573a21bd/ruff-0.12.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:71c83121512e7743fba5a8848c261dcc454cafb3ef2934a43f1b7a4eb5a447ea", size = 11702672 },
+    { url = "https://files.pythonhosted.org/packages/9d/ee/f9fdc9f341b0430110de8b39a6ee5fa68c5706dc7c0aa940817947d6937e/ruff-0.12.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:de4429ef2ba091ecddedd300f4c3f24bca875d3d8b23340728c3cb0da81072c3", size = 11440626 },
+    { url = "https://files.pythonhosted.org/packages/89/fb/b3aa2d482d05f44e4d197d1de5e3863feb13067b22c571b9561085c999dc/ruff-0.12.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a2cab5f60d5b65b50fba39a8950c8746df1627d54ba1197f970763917184b161", size = 12462162 },
+    { url = "https://files.pythonhosted.org/packages/18/9f/5c5d93e1d00d854d5013c96e1a92c33b703a0332707a7cdbd0a4880a84fb/ruff-0.12.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:45c32487e14f60b88aad6be9fd5da5093dbefb0e3e1224131cb1d441d7cb7d46", size = 12913212 },
+    { url = "https://files.pythonhosted.org/packages/71/13/ab9120add1c0e4604c71bfc2e4ef7d63bebece0cfe617013da289539cef8/ruff-0.12.8-py3-none-win32.whl", hash = "sha256:daf3475060a617fd5bc80638aeaf2f5937f10af3ec44464e280a9d2218e720d3", size = 11694382 },
+    { url = "https://files.pythonhosted.org/packages/f6/dc/a2873b7c5001c62f46266685863bee2888caf469d1edac84bf3242074be2/ruff-0.12.8-py3-none-win_amd64.whl", hash = "sha256:7209531f1a1fcfbe8e46bcd7ab30e2f43604d8ba1c49029bb420b103d0b5f76e", size = 12740482 },
+    { url = "https://files.pythonhosted.org/packages/cb/5c/799a1efb8b5abab56e8a9f2a0b72d12bd64bb55815e9476c7d0a2887d2f7/ruff-0.12.8-py3-none-win_arm64.whl", hash = "sha256:c90e1a334683ce41b0e7a04f41790c429bf5073b62c1ae701c9dc5b3d14f0749", size = 11884718 },
+]


### PR DESCRIPTION
## Overview
This PR introduces the initial implementation of CP932 (ShiftJIS) encoding/decoding functionality for Go, designed to be fully compatible with Python's codecs implementation. The package provides a drop-in replacement for `golang.org/x/text/transform` usage patterns.

## Key Features
- CP932 Encoding/Decoder: Full implementation of CP932 encoding with Python compatibility
- Transform Interface: Implements golang.org/x/text/transform.Transformer for seamless integration
- Comprehensive Testing: Extensive test coverage using Python-generated test data
- Development Tools: Added Makefile, linting configuration, and test coverage tools

## Technical Implementation
- Base Implementation: Built on top of golang.org/x/text/encoding/japanese.ShiftJIS
- Python Compatibility: Implements CP932-specific mappings that differ from standard ShiftJIS